### PR TITLE
Update TAGS.md

### DIFF
--- a/docs/TAGS.md
+++ b/docs/TAGS.md
@@ -15,7 +15,7 @@ Description: To make a task/play run always regardless of the tag specified. It'
 
 ### Tag - certificate_authority
 
-Description: To generate the certificate authority (CA) if TLS encryption is enabled and using self-signed certificates.
+Description: To generate the certificate authority (CA) if TLS encryption is enabled and using self-signed certificates.Additionally, a key pair for the MDS token, a private key and a public certificate, will be generated.
 
 ***
 


### PR DESCRIPTION

# Description

updated line 16 certificate_authority tag  description . 

Description: To generate the certificate authority (CA) if TLS encryption is enabled and using self-signed certificates.Additionally, a key pair for the MDS token, a private key and a public certificate, will be generated.

Fixes # (issue)
https://github.com/confluentinc/cp-ansible/issues/1560
## Type of change

edited description for docs/tags.md certificate_authority

# How Has This Been Tested?

https://docs.confluent.io/ansible/7.8/ansible-install.html

